### PR TITLE
Resolve Link differently in rich text

### DIFF
--- a/components/RichText.js
+++ b/components/RichText.js
@@ -88,9 +88,9 @@ function RichText(props) {
         const url = getUrlFromMapping(mappings, link.codename);
         if (url) {
           return (
-            <Link href={url}>
-              {domNode.children[0].data}
-            </Link>
+            <Link href={url}> 
+                {domToReact(domNode.children)}
+             </Link>
           );
         }
         else {


### PR DESCRIPTION
### Motivation

Fixes #42 

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Click thought the richtext resolution (`/style-guide` especially).
