### PR TITLE
Fix preview for navigation items

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -174,6 +174,9 @@ export async function getPageStaticPropsForPath(params, preview = false) {
   // TODO could be loaded right in getSitemapMappings
   const seoData = await client.item(navigationItemSystemInfo.codename)
     .elementsParameter(["seo__title", "label", "seo__description", "seo__keywords", "seo__canonical_url", "seo__options"])
+    .queryConfig({
+      usePreviewMode: preview
+    })
     .toPromise()
     .then(response => getRawKontentItemSingleResult(response))
     .then(response => ({


### PR DESCRIPTION
### Motivation

When the user created a new navigation item, the item was not using the preview endpoint for loading SEO data.

Error:
```js
DeliveryError {
  message: "The requested content item 'test_nav_item' was not found.",
  requestId: null,
  errorCode: 100,
  specificCode: 0
}
```

Add forgotten preview for SEO data loading.
Thx @mattnield for the notice!

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Tested manually